### PR TITLE
Add python2 pip to resolwebio/common

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -14,6 +14,7 @@ Added
 -----
 - Add assets from Google Drive that are used in ``resolwebio/common``
   Docker image
+- Add python2 pip to ``resolwebio/common:3.2.0`` image
 
 Changed
 -------

--- a/resolwe_docker_images/common/packages-manual.txt
+++ b/resolwe_docker_images/common/packages-manual.txt
@@ -12,3 +12,4 @@ r-packages
 samtools
 subread
 bwa-mem2
+pip2

--- a/resolwe_docker_images/common/packages-manual/pip2.sh
+++ b/resolwe_docker_images/common/packages-manual/pip2.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -e
+
+. /var/cache/build/packages-manual/common.sh
+
+# Python2 pip is no longer supported in Ubuntu 20.04 and bootstrapping
+# script has to be used to install pip, setuptools, and wheel
+download_and_verify \
+    bootstrap \
+    pypa \
+    2.7 \
+    40ee07eac6674b8d60fce2bbabc148cf0e2f1408c167683f110fd608b8d6f416 \
+    https://bootstrap.pypa.io/pip/\${version}/get-pip.py
+
+python2 /opt/bootstrap/pypa/get-pip.py
+rm -rf /opt/bootstrap


### PR DESCRIPTION
Because python2 pip can no longer be retrieved with `apt-get install python-pip` we have to include it in the common image to allow installing python2 packages in images derived from `resolwebio/common`.