### PR TITLE
Use resolwebio/base:ubuntu-20.04 as base image in resolwebio/latex:3.0.0

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -45,6 +45,8 @@ Changed
   ensure reproducibility by using Sesame cache files saved in assets for
   ``resolwebio/methylation_arrays:1.1.0`` Docker image
 - Remove unused ``sra-toolkit`` folder
+- Use ``resolwebio/base:ubuntu-20.04-03042021`` as a base image for
+  ``resolwebio/latex:3.0.0`` Docker image
 
 Fixed
 -----

--- a/resolwe_docker_images/latex/Dockerfile
+++ b/resolwe_docker_images/latex/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/resolwebio/base:ubuntu-16.04
+FROM public.ecr.aws/genialis/resolwebio/base:ubuntu-20.04-03042021
 
 MAINTAINER Resolwe Bioinformatics authors https://github.com/genialis/resolwe-bio
 

--- a/resolwe_docker_images/latex/README.md
+++ b/resolwe_docker_images/latex/README.md
@@ -1,7 +1,7 @@
 # Docker image for processes using LaTeX
 
-It is based on `ubuntu-16.04` version of [`docker.io/resolwebio/base`](
-https://hub.docker.com/r/resolwebio/base/) image.
+It is based on `ubuntu-20.04` version of [`resolwebio/base`](
+public.ecr.aws/genialis/resolwebio/base:ubuntu-20.04-03042021) image.
 
 Included packages:
 ------------------------------


### PR DESCRIPTION
`docker.io/resolwebio/base:ubuntu-16.04` could not be accessed and `resolwebio/base:ubuntu-16.04` is not available elsewhere.